### PR TITLE
Added `process` argument for waiting on non-parent processes

### DIFF
--- a/phook.c
+++ b/phook.c
@@ -45,7 +45,7 @@ Mandatory arguments to long options are mandatory for short options too\n\
   -a, --after=COMMAND        executes command after the parent process has ended\n\
   -e, --execute=COMMAND      executes command on start\n\
   -p, --process=PID          waits for PID to exit instead of parent process\n\
-      --help                 display this help and exit\n\
+  -h, --help                 display this help and exit\n\
       --version              output version information and exit\n\n\
 ");
         copyright();

--- a/phook.c
+++ b/phook.c
@@ -93,8 +93,12 @@ int main(int argc, char **argv) {
                     perror("process");
                 } else if (end == optarg || *end != '\0') {
                     fprintf(stderr, "process: Invalid argument\n");
-                } else if (p < INT_MIN || p > INT_MAX) {
+                } else if (p < 0) {
+                    fprintf(stderr, "process: Cannot be negative\n");
+                } else if (p > INT_MAX) {
                     fprintf(stderr, "process: Result too large\n");
+                } else if (p == 0) {
+                    fprintf(stderr, "process: Cannot watch pid 0\n");
                 } else {
                     ppid = (pid_t)p;
                     break;


### PR DESCRIPTION
If the `--process` argument is passed with a valid integer value, phook will wait for the process with that PID to exit instead of the parent process.
Also added a short `-h` option for help.
