### PR TITLE
Initialise ppid to 0 

### DIFF
--- a/phook.c
+++ b/phook.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
     int acode = 0;
     int ecode = 0;
     int optc;
-    pid_t ppid, fpid;
+    pid_t ppid = 0, fpid;
     struct kevent kev;
     int kq;
     int kret;


### PR DESCRIPTION
As discussed in #8 - fixes the after hook not firing due to ppid being initialised to a non-zero value (and so being interpreted as if `-p xxxx` had been passed.